### PR TITLE
chore:dockerized the frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  testgrid-frontend:
+    build: ./frontend
+    ports:
+      - 8001:5173
+
+  testgrid-api:
+    build: ./backend-api
+    env_file: ./backend-api/base.env
+    ports:
+      - 8000:80

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:alpine3.18
+
+WORKDIR /app
+
+# COPY public/ /app/public
+
+# COPY src/ app/src
+
+# COPY package*.json /app/
+COPY . /app/
+
+RUN npm install
+
+CMD ["npm", "run", "prod"]

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+
+services:
+  testgrid-frontend:
+    build: .
+    ports:
+      - 8001:5173

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prod": "vite --host",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
Trello Reference: [TESTGRID-8](https://trello.com/c/jBht3y0P/8-dockerize-frontend)

### Background
we need the frontend app to be dockerized so it can be run on the server without then need for any setup

### Changes

- added docker files to dockerize the frontend
- added a docker compose file to run both the backend and the frontend together


### Tests
manual testing