### PR TITLE
feat: add ability to run network scan tests on test server

### DIFF
--- a/backend-api/app/api/api_v1/api.py
+++ b/backend-api/app/api/api_v1/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from app.api.api_v1.endpoints import users
+from app.api.api_v1.endpoints import users, tasks
 from app.api.deps import check_api_key
 
 api_router_v1 = APIRouter()
@@ -8,5 +8,10 @@ api_router_v1 = APIRouter()
 api_router_v1.include_router(users.router, 
                              prefix='/auth', 
                              tags=['users'], 
+                             dependencies=[Depends(check_api_key)])
+
+api_router_v1.include_router(tasks.router, 
+                             prefix='/test', 
+                             tags=['tasks'], 
                              dependencies=[Depends(check_api_key)])
 

--- a/backend-api/app/api/api_v1/endpoints/tasks.py
+++ b/backend-api/app/api/api_v1/endpoints/tasks.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, status, Path, HTTPException, Body, Security
+
+from typing import Annotated
+
+
+from app.celery_app import celery_app
+from app.schemas.tasks import TaskRunRequest
+from app.enums.tasks import TaskField, TaskType
+from app.core.config import settings
+from app.logs.log_conf import Logger
+
+logger = Logger(__name__)
+
+
+router = APIRouter()
+
+
+@router.post("/run-test",
+            status_code=status.HTTP_200_OK,
+            description="request a new task run")
+async def run_task(task_run_request: Annotated[TaskRunRequest, Body(...)]):
+    if task_run_request.task_field == TaskField.penetration_test:
+        if task_run_request.task_type == TaskType.network_scan:
+            logger.info(f'running a task of field {task_run_request.task_field} and type {task_run_request.task_type}')
+            celery_app.send_task('demo_task.run_nmap', list(task_run_request.task_params.values()), reply_to=settings.RESULT_BACKEND_QUEUE)

--- a/backend-api/app/celery_app/__init__.py
+++ b/backend-api/app/celery_app/__init__.py
@@ -1,0 +1,9 @@
+from celery import Celery
+from app.core.config import settings
+from app.logs.log_conf import Logger
+
+logger = Logger(__name__)
+
+celery_app = Celery(__name__,
+            broker=str(settings.CELERY_BROKER),
+            result_backend=str(settings.CELERY_RESULT_BACKEND))

--- a/backend-api/app/core/config.py
+++ b/backend-api/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import EmailStr, MongoDsn, validator, field_validator
+from pydantic import EmailStr, MongoDsn, validator, field_validator, AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.logs.log_conf import Logger
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Default Project"
 
     ENABLE_AUTH_FEATURE: bool = True
+
+    CELERY_BROKER: AnyUrl
+    CELERY_RESULT_BACKEND: AnyUrl
+    RESULT_BACKEND_QUEUE: str
 
     model_config = SettingsConfigDict(case_sensitive=True)
 

--- a/backend-api/app/enums/tasks.py
+++ b/backend-api/app/enums/tasks.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class TaskStatusEnum(str, Enum):
+    drafted = 'DRAFTED'
+    pending = 'PENDING'
+    running = 'RUNNING'
+    success = 'SUCCESS'
+    canceled = 'CANCELED'
+    failed = 'FAILED'
+
+class TaskField(str, Enum):
+    penetration_test = 'penetration_test'
+    limit_test = 'limit_test'
+
+class TaskType(str, Enum):
+    network_scan = "network_scan"
+    web_sql_scan = 'web_sql_scan'
+    web_js_scan = 'web_js_scan'
+    web_dir_enumeration_scan = 'web_dir_enumeration_scan'

--- a/backend-api/app/models/tasks.py
+++ b/backend-api/app/models/tasks.py
@@ -1,0 +1,20 @@
+from beanie import Document, Indexed
+from pydantic import UUID4
+from datetime import datetime
+from app.enums.tasks import TaskStatusEnum, TaskField, TaskType
+from typing import Annotated
+
+current_datetime = datetime.utcnow()
+
+class TaskRun(Document):
+    task_id: Annotated[UUID4, Indexed(unique=True)]
+    task_field: TaskField
+    task_type: TaskType
+    created_at: datetime = current_datetime
+    updated_at: datetime = current_datetime
+    status: TaskStatusEnum = TaskStatusEnum.pending
+    result: dict
+ 
+    class Settings:
+        name = "TaskRun"
+        validate_on_save = True # instead of validate on assignment

--- a/backend-api/app/schemas/tasks.py
+++ b/backend-api/app/schemas/tasks.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, EmailStr
+from datetime import datetime
+
+from app.enums.tasks import TaskField, TaskType
+
+
+
+class TaskRunRequest(BaseModel):
+    task_field: TaskField
+    task_type: TaskType
+    task_params: dict

--- a/backend-api/env.example
+++ b/backend-api/env.example
@@ -12,3 +12,7 @@ PROJECT_NAME="TestGrid - Cloud-Based Load Testing & Penetration Testing Tool"
 
 #feature flags
 ENABLE_AUTH_FEATURE=True
+
+CELERY_BROKER=
+CELERY_RESULT_BACKEND=
+RESULT_BACKEND_QUEUE=


### PR DESCRIPTION
Trello Reference: [TESTGRID-15](https://trello.com/c/f6K0uqxd/15-build-test-configuration-page)

### Background
Added the ability to run tests with API requests to the route `/tests/run-test`

### Changes

- added `/tests/run-test` route to run tests
- setup celery


### Tests
manual testing