### PR TITLE
chore: return test celery id on test run

### DIFF
--- a/backend-api/app/api/api_v1/endpoints/tasks.py
+++ b/backend-api/app/api/api_v1/endpoints/tasks.py
@@ -37,6 +37,7 @@ async def run_task(task_run_request: Annotated[TaskRunRequest, Body(...)],
     logger.info('storing task run in db...')
     task: InitialTaskRunSchema = InitialTaskRunSchema(task_celery_id=task_result.id, task_field=task_run_request.task_field, task_type=task_run_request.task_type, status=task_result.status)
     await TaskCrud.insert_task_run(task, user)
+    return {"task_id": task_result.id}
 
 @router.get("/user-tests",
             status_code=status.HTTP_200_OK,


### PR DESCRIPTION
Trello Reference: [TESTGRID-15](https://trello.com/c/f6K0uqxd/15-build-test-configuration-page)

### Background
we need a way to redirect users to their test result page upon test run

### Changes

- made `/test/run-test` route return celery task ID on task run



### Tests
manual testing