### PR TITLE
fix: assign actual created_at dates

### DIFF
--- a/backend-api/app/models/tasks.py
+++ b/backend-api/app/models/tasks.py
@@ -1,17 +1,16 @@
 from beanie import Document, Indexed, PydanticObjectId
-from pydantic import UUID4
+from pydantic import UUID4, model_validator
 from datetime import datetime
 from app.enums.tasks import TaskStatusEnum, TaskField, TaskType
-from typing import Annotated
+from typing import Annotated, Any
 
-current_datetime = datetime.utcnow()
 
 class TaskRunDocument(Document):
     task_celery_id: Annotated[UUID4, Indexed(unique=True)]
     task_field: TaskField
     task_type: TaskType
-    created_at: datetime = current_datetime
-    updated_at: datetime = current_datetime
+    created_at: datetime
+    updated_at: datetime
     status: TaskStatusEnum = TaskStatusEnum.running
     result: dict | None = None
     user_id: Annotated[PydanticObjectId, Indexed()]
@@ -19,3 +18,12 @@ class TaskRunDocument(Document):
     class Settings:
         name = "tasks"
         validate_on_save = True # instead of validate on assignment
+
+    @model_validator(mode='before')
+    @classmethod
+    def assign_dates(cls, data: Any) -> Any:
+        current_datetime = datetime.utcnow()
+        if isinstance(data, dict):
+            data['created_at'] = current_datetime
+            data['updated_at'] = current_datetime
+        return data

--- a/backend-api/app/models/users.py
+++ b/backend-api/app/models/users.py
@@ -1,17 +1,16 @@
 from beanie import Document, Indexed
-from pydantic import EmailStr
+from pydantic import EmailStr, model_validator
 from datetime import datetime
 from app.enums.users import UserTypesEnum
-from typing import Annotated
+from typing import Annotated, Any
 
-current_datetime = datetime.utcnow()
 
 class UserDocument(Document):
     email: Annotated[EmailStr, Indexed(unique=True)]
     username: Annotated[str, Indexed(unique=True)]
     password: str
-    created_at: datetime = current_datetime
-    updated_at: datetime = current_datetime
+    created_at: datetime
+    updated_at: datetime
     user_type: UserTypesEnum = UserTypesEnum.normal_user
     active: bool = False
     disabled: bool = False
@@ -19,5 +18,14 @@ class UserDocument(Document):
     class Settings:
         name = "users"
         validate_on_save = True # instead of validate on assignment
+
+    @model_validator(mode='before')
+    @classmethod
+    def assign_dates(cls, data: Any) -> Any:
+        current_datetime = datetime.utcnow()
+        if isinstance(data, dict):
+            data['created_at'] = current_datetime
+            data['updated_at'] = current_datetime
+        return data
 
 


### PR DESCRIPTION
Trello Reference: [TESTGRID-31](https://trello.com/c/7QWPcf04/31-fix-createdat-date-bug)

### Background
`created_at` and `updated_at` initial values were being assigned false times. they were assigned the time that the app started at 
 where the `current_time` variable was calculated once

### Changes

- add a pre-validator that calculates the correct time and assign it to `created_at` and `updated_at`

### Tests
manual testing