### PR TITLE
fix: temporary fix by removing loop

### DIFF
--- a/backend-api/app/workers/celery_task_event_handler.py
+++ b/backend-api/app/workers/celery_task_event_handler.py
@@ -33,15 +33,15 @@ def task_event_handler():
     def task_event_handler(event):
         state.event(event)
         task = state.tasks.get(event['uuid'])
-        while not check_task_exists(task.id):
-            continue
+        # while not check_task_exists(task.id):
+        #     continue
         request_to_update_task(task.id)
 
     def task_event_succeeded_handler(event):
         state.event(event)
         task = state.tasks.get(event['uuid'])
-        while not check_task_exists(task.id):
-            continue
+        # while not check_task_exists(task.id):
+        #     continue
         request_to_update_task(task.id)
 
     with celery_app.connection() as connection:


### PR DESCRIPTION
Trello Reference: [TESTGRID-34](https://trello.com/c/A62ZZtKC/34-solve-celery-event-listener-hanging)

### Background
there are cases where the celery event listener hangs due the the loop that checks if a task exists. for example:

if the local env uses the same celery worker as the remote one. then the local one will have task ids that the remote worker doesn’t know about so the remote worker will hang in an infinite loop when querying for those tasks

### Changes

- removed checking loop as a temp solution




### Tests
manual testing